### PR TITLE
feat(log): implement server action for creating log entries

### DIFF
--- a/prisma/migrations/20250705072422_add_cascade_delete_to_spaces/migration.sql
+++ b/prisma/migrations/20250705072422_add_cascade_delete_to_spaces/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Space" DROP CONSTRAINT "Space_owner_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Space" ADD CONSTRAINT "Space_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "Profile"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,7 @@ model Space {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 
-  owner       Profile       @relation(fields: [owner_id], references: [user_id])
+  owner       Profile       @relation(fields: [owner_id], references: [user_id], onDelete: Cascade)
   members     SpaceMember[]
   log_entries LogEntry[]
 

--- a/src/actions/log-actions.ts
+++ b/src/actions/log-actions.ts
@@ -1,0 +1,104 @@
+'use server';
+
+import { prisma } from '@/lib/db';
+import { Prisma } from '@prisma/client';
+import { createClient } from '@/lib/supabase/server';
+import { logEntrySchema, LogEntryFormValues } from '@/lib/schemas/log-schema';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+interface ActionResult {
+    success: boolean;
+    message: string;
+}
+
+export async function createLogEntry(
+    values: LogEntryFormValues
+): Promise<ActionResult> {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+        return { success: false, message: 'Authentication required.' };
+    }
+
+    const validatedFields = logEntrySchema.safeParse(values);
+
+    if (!validatedFields.success) {
+        return {
+            success: false,
+            message: `Invalid form data: ${validatedFields.error.flatten().formErrors.join(', ')}`,
+        };
+    }
+    const { tmdbId, tmdbType, rating, watchedOn, quickTake, deeperThoughts } = validatedFields.data;
+
+    try {
+        const personalSpace = await prisma.space.findFirst({
+            where: {
+                owner_id: user.id,
+                type: 'PERSONAL',
+            },
+        });
+
+        if (!personalSpace) {
+            return { success: false, message: 'Could not find a personal space for this user.' };
+        }
+
+        await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+            const logEntry = await tx.logEntry.upsert({
+                where: {
+                    space_id_tmdb_id_tmdb_type: {
+                        space_id: personalSpace.id,
+                        tmdb_id: tmdbId,
+                        tmdb_type: tmdbType,
+                    }
+                },
+                update: {},
+                create: {
+                    space_id: personalSpace.id,
+                    tmdb_id: tmdbId,
+                    tmdb_type: tmdbType,
+                },
+            });
+
+            const ratingRecord = await tx.rating.create({
+                data: {
+                    log_entry_id: logEntry.id,
+                    user_id: user.id,
+                    value: rating,
+                    watched_on: watchedOn,
+                },
+            });
+
+            if (quickTake) {
+                await tx.comment.create({
+                    data: {
+                        rating_id: ratingRecord.id,
+                        user_id: user.id,
+                        type: 'QUICK_TAKE',
+                        content: quickTake,
+                    },
+                });
+            }
+            if (deeperThoughts) {
+                await tx.comment.create({
+                    data: {
+                        rating_id: ratingRecord.id,
+                        user_id: user.id,
+                        type: 'DEEPER_THOUGHTS',
+                        content: deeperThoughts,
+                    },
+                });
+            }
+        });
+    } catch (error) {
+        console.error('Database Error:', error);
+        if (error instanceof Prisma.PrismaClientKnownRequestError) {
+            console.error('Prisma Error Code:', error.code);
+        }
+        return { success: false, message: 'Failed to create log entry in the database.' };
+    }
+
+    revalidatePath('/');
+    redirect('/');
+}

--- a/src/components/features/log/LogForm.tsx
+++ b/src/components/features/log/LogForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
+import { createLogEntry } from '@/actions/log-actions';
 
 import { LogEntryFormValues, logEntrySchema } from '@/lib/schemas/log-schema';
 import { cn } from '@/lib/utils';
@@ -43,8 +44,12 @@ export function LogForm() {
         },
     });
 
-    function onSubmit(values: LogEntryFormValues) {
-        console.log('Form Submitted:', values);
+    async function onSubmit(values: LogEntryFormValues) {
+        const result = await createLogEntry(values);
+        if (!result.success) {
+            console.error('Failed to create log entry:', result.message);
+            alert(`Error: ${result.message}`); // Simple alert for now
+        }
     }
 
     return (

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+    prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+    globalForPrisma.prisma ??
+    new PrismaClient({
+        log: ['query', 'info', 'warn', 'error'],
+    });
+
+if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
Creates the complete backend logic for the logging form submission. This server action handles authentication, server-side validation, and transactional database writes.

- Implements the `createLogEntry` server action to securely process form data.
- Validates incoming data against the Zod schema on the server to ensure integrity.
- Uses a Prisma transaction (`$transaction`) to create `LogEntry`, `Rating`, and `Comment` records atomically.
- Implements `logEntry.upsert` to prevent duplicate media entries within a space.
- Establishes a Prisma Client singleton in `lib/db.ts` for efficient database connection management.
- Revalidates the home page path and redirects the user upon successful submission.

Closes Milestone 1.4.