### PR TITLE
feat(notifications): add real-time pending rating notifications

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Poppins, Source_Sans_3 as SourceSansPro } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { Toaster } from '@/components/ui/sonner';
+import { RealtimeNotificationProvider } from '@/components/providers/realtime-provider';
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -39,6 +40,7 @@ export default function RootLayout({
       >
         {children}
         <Toaster richColors />
+        <RealtimeNotificationProvider />
       </body>
     </html>
   );

--- a/src/components/providers/realtime-provider.tsx
+++ b/src/components/providers/realtime-provider.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { toast } from 'sonner';
+import { createBrowserClient } from '@supabase/ssr';
+import type { User } from '@supabase/supabase-js';
+
+import { useRealtimeSubscription } from '@/hooks/use-realtime-subscription';
+import type { PendingRating } from '@prisma/client';
+
+/**
+ * A provider component that sets up a real-time subscription
+ * for pending rating notifications and displays them as toasts.
+ * It only activates when a user is logged in.
+ */
+export function RealtimeNotificationProvider() {
+    const [user, setUser] = useState<User | null>(null);
+    const pathname = usePathname();
+
+    useEffect(() => {
+        const supabase = createBrowserClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+        );
+
+        const getUser = async () => {
+            const { data } = await supabase.auth.getUser();
+            setUser(data.user);
+        };
+
+        getUser();
+    }, [pathname]);
+
+    const handleNewPendingRating = (payload: PendingRating) => {
+        console.log('New pending rating received:', payload);
+
+        toast.info("Your Turn! You have a new item to rate.", {
+            description: "A new movie or show was logged in one of your shared spaces.",
+            action: {
+                label: "View",
+                onClick: () => {
+                    console.log("View action clicked");
+                }
+            }
+        });
+    };
+
+    useRealtimeSubscription<PendingRating>(
+        'PendingRating',
+        `user_id=eq.${user?.id}`,
+        handleNewPendingRating
+    );
+
+    return null;
+}

--- a/src/hooks/use-realtime-subscription.ts
+++ b/src/hooks/use-realtime-subscription.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { createBrowserClient } from '@supabase/ssr';
+import { RealtimeChannel } from '@supabase/supabase-js';
+
+type RealtimeCallback<T> = (payload: T) => void;
+
+/**
+ * A generic React hook for subscribing to Supabase Realtime changes on a specific table.
+ *
+ * @param tableName The name of the table to subscribe to.
+ * @param filter The RLS filter to apply (e.g., `user_id=eq.${userId}`).
+ * @param onInsert A callback function to run when a new row is inserted.
+ */
+export function useRealtimeSubscription<T extends { [key: string]: any }>(
+    tableName: string,
+    filter: string,
+    onInsert: RealtimeCallback<T>
+) {
+    const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+
+    useEffect(() => {
+        let channel: RealtimeChannel;
+
+        const setupSubscription = () => {
+            channel = supabase
+                .channel(`public:${tableName}:${filter}`)
+                .on<T>(
+                    'postgres_changes',
+                    { event: 'INSERT', schema: 'public', table: tableName, filter },
+                    (payload) => {
+                        onInsert(payload.new);
+                    }
+                )
+                .subscribe();
+        };
+
+        setupSubscription();
+
+        return () => {
+            if (channel) {
+                supabase.removeChannel(channel);
+            }
+        };
+    }, [tableName, filter, onInsert, supabase]);
+}


### PR DESCRIPTION
This PR implements Milestone 2.4, introducing real-time notifications for the "Pending Ratings" feature using Supabase Realtime. When a user logs a new entry in a shared space, other members are now instantly notified that it's their turn to rate.

### Changes Implemented

-   **Supabase Realtime Enabled (P2.4.1):**
    -   Enabled Realtime broadcasting for the `PendingRating` table via the Supabase Dashboard (under Database > Publications).

-   **Reusable Realtime Hook (P2.4.2):**
    -   Created a generic and reusable `useRealtimeSubscription` custom hook to encapsulate the logic for subscribing to Supabase Realtime channels.
    -   This hook handles channel setup, event listening, and proper cleanup on unmount to prevent memory leaks.

-   **Notification Provider (P2.4.3 & P2.4.4):**
    -   Created a new `RealtimeNotificationProvider` client component.
    -   This provider uses the `useRealtimeSubscription` hook to listen specifically for `INSERT` events on the `PendingRating` table that are assigned to the currently authenticated user.
    -   When a new event is received, it triggers a toast notification using `sonner` to alert the user.
    -   The provider has been added to the root layout to ensure it's active for any logged-in user across the application.

### Related Tasks

- Closes Milestone 2.4