### PR TITLE
feat(integrations): add discord webhook support

### DIFF
--- a/prisma/migrations/20250711124407_add_discord_webhook_to_space/migration.sql
+++ b/prisma/migrations/20250711124407_add_discord_webhook_to_space/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Space" ADD COLUMN     "discord_webhook_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Space {
   name      String
   type      SpaceType @default(PERSONAL)
   owner_id  String    @db.Uuid
+  discord_webhook_url String?
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 

--- a/src/app/spaces/[spaceId]/settings/page.tsx
+++ b/src/app/spaces/[spaceId]/settings/page.tsx
@@ -14,6 +14,7 @@ import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { InviteMemberForm } from '@/components/features/space/invite-member-form';
 import { RemoveMemberButton } from '@/components/features/space/remove-member-button';
+import { DiscordWebhookForm } from '@/components/features/space/discord-webhook-form';
 
 type SpaceWithMembersAndProfiles = Prisma.SpaceGetPayload<{
     include: {
@@ -113,10 +114,10 @@ export default async function SpaceSettingsPage({
                                     if (!profile) return null;
 
                                     const canBeRemoved =
-                                        isCurrentUserAdmin &&  
+                                        isCurrentUserAdmin &&
                                         profile.user_id !== currentUser.id &&
-                                        profile.user_id !== space.owner_id && 
-                                        role !== 'ADMIN'; 
+                                        profile.user_id !== space.owner_id &&
+                                        role !== 'ADMIN';
 
                                     return (
                                         <li
@@ -174,6 +175,23 @@ export default async function SpaceSettingsPage({
                             <InviteMemberForm spaceId={space.id} />
                         </CardContent>
                     </Card>
+
+                    {isCurrentUserAdmin && (
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Discord Integration</CardTitle>
+                                <CardDescription>
+                                    Automatically post new log entries to a Discord channel.
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent>
+                                <DiscordWebhookForm
+                                    spaceId={space.id}
+                                    currentWebhookUrl={space.discord_webhook_url}
+                                />
+                            </CardContent>
+                        </Card>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/components/features/space/discord-webhook-form.tsx
+++ b/src/components/features/space/discord-webhook-form.tsx
@@ -1,11 +1,9 @@
 'use client';
-
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTransition } from 'react';
 import { toast } from 'sonner';
 import Link from 'next/link';
-
 import {
     discordWebhookSchema,
     type DiscordWebhookFormValues,
@@ -44,7 +42,6 @@ export function DiscordWebhookForm({
     function onSubmit(values: DiscordWebhookFormValues) {
         startTransition(async () => {
             const result = await saveDiscordWebhook(spaceId, values.webhookUrl);
-
             if (result.success) {
                 toast.success('Discord webhook URL saved!');
                 form.reset({ webhookUrl: values.webhookUrl });
@@ -70,9 +67,8 @@ export function DiscordWebhookForm({
                                 />
                             </FormControl>
                             <FormDescription>
-                                Paste the URL from your Discord channel's integration settings.
+                                Paste the URL from your Discord channel&apos;s integration settings.
                             </FormDescription>
-
                             <FormDescription>
                                 <Link
                                     href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks"
@@ -83,7 +79,6 @@ export function DiscordWebhookForm({
                                     Learn how to create a webhook.
                                 </Link>
                             </FormDescription>
-
                             <FormMessage />
                         </FormItem>
                     )}

--- a/src/components/features/space/discord-webhook-form.tsx
+++ b/src/components/features/space/discord-webhook-form.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+import {
+    discordWebhookSchema,
+    type DiscordWebhookFormValues,
+} from '@/lib/schemas/space-schemas';
+import {
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { saveDiscordWebhook } from '@/actions/space-actions';
+
+interface DiscordWebhookFormProps {
+    spaceId: string;
+    currentWebhookUrl: string | null;
+}
+
+export function DiscordWebhookForm({
+    spaceId,
+    currentWebhookUrl,
+}: DiscordWebhookFormProps) {
+    const [isPending, startTransition] = useTransition();
+
+    const form = useForm<DiscordWebhookFormValues>({
+        resolver: zodResolver(discordWebhookSchema),
+        defaultValues: {
+            webhookUrl: currentWebhookUrl ?? '',
+        },
+    });
+
+    function onSubmit(values: DiscordWebhookFormValues) {
+        startTransition(async () => {
+            const result = await saveDiscordWebhook(spaceId, values.webhookUrl);
+
+            if (result.success) {
+                toast.success('Discord webhook URL saved!');
+                form.reset({ webhookUrl: values.webhookUrl });
+            } else {
+                toast.error(result.error);
+            }
+        });
+    }
+
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <FormField
+                    control={form.control}
+                    name="webhookUrl"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Webhook URL</FormLabel>
+                            <FormControl>
+                                <Input
+                                    placeholder="https://discord.com/api/webhooks/..."
+                                    {...field}
+                                />
+                            </FormControl>
+                            <FormDescription>
+                                Paste the URL from your Discord channel's integration settings.
+                            </FormDescription>
+
+                            <FormDescription>
+                                <Link
+                                    href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-sm text-muted-foreground underline hover:text-foreground"
+                                >
+                                    Learn how to create a webhook.
+                                </Link>
+                            </FormDescription>
+
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <Button type="submit" disabled={isPending}>
+                    {isPending ? 'Saving...' : 'Save'}
+                </Button>
+            </form>
+        </Form>
+    );
+}

--- a/src/lib/schemas/space-schemas.ts
+++ b/src/lib/schemas/space-schemas.ts
@@ -23,4 +23,14 @@ export const inviteMemberSchema = z.object({
         .min(3, { message: 'Username must be at least 3 characters.' }),
 });
 
+/**
+ * Schema for adding a Discord Webhook URL.
+ * Validates that the URL is provided.
+ */
 export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
+
+export const discordWebhookSchema = z.object({
+    webhookUrl: z.string().url({ message: 'Please enter a valid Discord webhook URL.' }).or(z.literal('')),
+});
+
+export type DiscordWebhookFormValues = z.infer<typeof discordWebhookSchema>;

--- a/src/lib/services/discord-service.ts
+++ b/src/lib/services/discord-service.ts
@@ -1,0 +1,87 @@
+import { buildPosterUrl } from '@/lib/tmdb/tmdb-utils';
+import { getTmdbMediaDetails, TmdbMovieDetails } from '@/lib/tmdb/tmdb-client';
+import type { LogEntry, Profile, Rating, Comment } from '@prisma/client';
+
+export type DiscordNotificationData = {
+    logEntry: LogEntry;
+    rating: Rating & { user: Profile; comments: Comment[] };
+};
+
+function isMovie(details: any): details is TmdbMovieDetails {
+    return details !== null && 'title' in details;
+}
+
+async function constructDiscordEmbed(notificationData: DiscordNotificationData) {
+    const { logEntry, rating } = notificationData;
+    const { user, comments } = rating;
+
+    const mediaDetails = await getTmdbMediaDetails(
+        logEntry.tmdb_id,
+        logEntry.tmdb_type as 'movie' | 'tv'
+    );
+
+    if (!mediaDetails) {
+        console.error(`Could not fetch media details for tmdbId: ${logEntry.tmdb_id}`);
+        return null;
+    }
+
+    const title = isMovie(mediaDetails) ? mediaDetails.title : mediaDetails.name;
+    const releaseYear = (isMovie(mediaDetails) ? mediaDetails.release_date : mediaDetails.first_air_date)?.substring(0, 4);
+
+    const quickTakeComment = comments.find(c => c.type === 'QUICK_TAKE');
+    const stars = '⭐'.repeat(Math.floor(rating.value)) + (rating.value % 1 !== 0 ? '✨' : '');
+
+    let description = `**${rating.value.toFixed(1)}** ${stars}\n`;
+    if (quickTakeComment) {
+        description += `> ${quickTakeComment.content}`;
+    }
+
+    const embed = {
+        content: `${user.display_name} just logged a new entry!`,
+        embeds: [
+            {
+                title: `${title} (${releaseYear})`,
+                url: `https://www.themoviedb.org/${logEntry.tmdb_type}/${logEntry.tmdb_id}`,
+                description: description,
+                color: 13915497,
+                image: {
+                    url: buildPosterUrl(mediaDetails.poster_path, 'w500'),
+                },
+                author: {
+                    name: `${user.display_name} (@${user.username})`,
+                    icon_url: user.avatar_url ?? undefined,
+                },
+                footer: {
+                    text: 'Logged with Flicklog',
+                    icon_url: 'https://i.imgur.com/hC4zF24.png',
+                },
+                timestamp: new Date().toISOString(),
+            },
+        ],
+    };
+
+    return embed;
+}
+
+export async function postToDiscord(webhookUrl: string, notificationData: DiscordNotificationData) {
+    const payload = await constructDiscordEmbed(notificationData);
+
+    if (!payload) {
+        console.error("Failed to construct Discord embed, aborting post.");
+        return;
+    }
+
+    try {
+        const response = await fetch(webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            console.error(`Discord API Error: ${response.status} ${response.statusText}`, await response.json());
+        }
+    } catch (error) {
+        console.error("Failed to post notification to Discord:", error);
+    }
+}


### PR DESCRIPTION
Implements the ability for space admins to connect a Discord webhook to a space for automatic new entry notifications.

- Adds 'discord_webhook_url' to the Space model.
- Creates a form in Space Settings for admins to save the webhook URL.
- Implements 'saveDiscordWebhook' server action to securely save the URL.
- Creates a 'discord-service' to construct and post rich embeds.
- Refactors 'createLogEntry' and 'submitPendingRating' actions to call the new service, sending a notification upon successful creation of a rating.