### PR TITLE
feat(ui): implement light/dark theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,3 @@
-/* src/app/globals.css */
 @import 'tailwindcss';
 @import "tw-animate-css";
 
@@ -20,36 +19,47 @@
 }
 
 :root {
-  --background: oklch(0.151 0.012 259.4);
-  --foreground: oklch(0.914 0.011 82.9);
-  --card: oklch(0.203 0.014 259.6);
-  --card-foreground: oklch(0.914 0.011 82.9);
-  --popover: oklch(0.203 0.014 259.6);
-  --popover-foreground: oklch(0.914 0.011 82.9);
-  --primary: oklch(0.704 0.094 78.4);
-  --primary-foreground: oklch(0.151 0.012 259.4);
-  --secondary: oklch(0.203 0.014 259.6);
-  --secondary-foreground: oklch(0.704 0.094 78.4);
-  --muted: oklch(0.203 0.014 259.6);
-  --muted-foreground: oklch(0.914 0.011 82.9 / 0.6);
-  --accent: oklch(0.203 0.014 259.6);
-  --accent-foreground: oklch(0.914 0.011 82.9);
+  --background: oklch(0.96 0.009 82);
+  /* #F5F2EF */
+  --foreground: oklch(0.151 0.012 259.4);
+  /* #1A1D23 */
+  --card: oklch(1 0 0);
+  /* #FFFFFF */
+  --card-foreground: oklch(0.151 0.012 259.4);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.151 0.012 259.4);
+  --primary: oklch(0.65 0.1 85);
+  /* A slightly darker gold for light bg */
+  --primary-foreground: oklch(0.96 0.009 82);
+  --secondary: oklch(0.94 0.01 82);
+  /* A subtle off-white for secondary buttons */
+  --secondary-foreground: oklch(0.151 0.012 259.4);
+  --muted: oklch(0.94 0.01 82);
+  --muted-foreground: oklch(0.151 0.012 259.4 / 0.6);
+  --accent: oklch(0.94 0.01 82);
+  --accent-foreground: oklch(0.151 0.012 259.4);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.914 0.011 82.9);
-  --border: oklch(0.704 0.094 78.4 / 0.2);
-  --input: oklch(0.704 0.094 78.4 / 0.2);
-  --ring: oklch(0.704 0.094 78.4 / 0.8);
+  --destructive-foreground: oklch(0.96 0.009 82);
+  --border: oklch(0.151 0.012 259.4 / 0.1);
+  /* Lighter border */
+  --input: oklch(0.151 0.012 259.4 / 0.1);
+  --ring: oklch(0.65 0.1 85 / 0.8);
   --radius: 0.5rem;
 }
 
+/* --- DARK THEME --- */
 .dark {
   --background: oklch(0.151 0.012 259.4);
+  /* #1A1D23 */
   --foreground: oklch(0.914 0.011 82.9);
+  /* #EAE6E1 */
   --card: oklch(0.203 0.014 259.6);
+  /* #252931 */
   --card-foreground: oklch(0.914 0.011 82.9);
   --popover: oklch(0.203 0.014 259.6);
   --popover-foreground: oklch(0.914 0.011 82.9);
   --primary: oklch(0.704 0.094 78.4);
+  /* #D4A269 */
   --primary-foreground: oklch(0.151 0.012 259.4);
   --secondary: oklch(0.203 0.014 259.6);
   --secondary-foreground: oklch(0.704 0.094 78.4);
@@ -94,6 +104,7 @@
   * {
     @apply border-border;
   }
+
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "kern" on, "liga" on;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,29 @@
-import type { Metadata } from "next";
-import { Poppins, Source_Sans_3 as SourceSansPro } from "next/font/google";
-import "./globals.css";
-import { cn } from "@/lib/utils";
+import type { Metadata } from 'next';
+import { Poppins, Source_Sans_3 as SourceSansPro } from 'next/font/google';
+import './globals.css';
+import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/sonner';
 import { SupabaseProvider } from '@/components/providers/supabase-provider';
 import { RealtimeNotificationProvider } from '@/components/providers/realtime-provider';
+import { ThemeProvider } from '@/components/providers/theme-provider';
 
 const poppins = Poppins({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-poppins",
-  weight: ["600", "700"],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-poppins',
+  weight: ['600', '700'],
 });
 
 const sourceSansPro = SourceSansPro({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-source-sans-pro",
-  weight: ["400", "500", "600"],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-source-sans-pro',
+  weight: ['400', '500', '600'],
 });
 
 export const metadata: Metadata = {
-  title: "Flicklog",
-  description: "Your personal and shared movie scrapbook.",
+  title: 'Flicklog',
+  description: 'Your personal and shared movie scrapbook.',
 };
 
 export default function RootLayout({
@@ -31,20 +32,26 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          "min-h-screen font-body antialiased",
+          'min-h-screen font-body antialiased',
           poppins.variable,
           sourceSansPro.variable
         )}
       >
-        <SupabaseProvider>
-          {children}
-          <Toaster richColors />
-          <RealtimeNotificationProvider />
-        </SupabaseProvider>
-
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem={false}
+          disableTransitionOnChange
+        >
+          <SupabaseProvider>
+            {children}
+            <Toaster richColors />
+            <RealtimeNotificationProvider />
+          </SupabaseProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/spaces/[spaceId]/layout.tsx
+++ b/src/app/spaces/[spaceId]/layout.tsx
@@ -7,6 +7,8 @@ import { SpaceSwitcher } from '@/components/shared/space-switcher';
 import { buttonVariants } from '@/components/ui/button';
 import { LayoutGrid, Settings } from 'lucide-react';
 import { UserNav } from '@/components/shared/user-nav';
+import { Separator } from '@/components/ui/separator';
+import { ThemeToggleSwitch } from '@/components/shared/theme-toggle-switch';
 
 /**
  * Layout for a specific space.
@@ -81,6 +83,8 @@ export default async function SpaceLayout({
                         >
                             + Log New
                         </Link>
+                        <ThemeToggleSwitch />
+                        <Separator orientation="vertical" className="h-8" />
                         <UserNav
                             email={user.email}
                             avatarUrl={userProfile?.avatar_url}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,10 @@
+'use client';
+import * as React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ComponentProps } from 'react';
+
+type NextThemesProviderProps = ComponentProps<typeof NextThemesProvider>;
+
+export function ThemeProvider({ children, ...props }: NextThemesProviderProps) {
+    return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/shared/theme-toggle-switch.tsx
+++ b/src/components/shared/theme-toggle-switch.tsx
@@ -1,0 +1,42 @@
+'use client';
+import * as React from 'react';
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggleSwitch() {
+    const { setTheme, theme } = useTheme();
+    const [mounted, setMounted] = React.useState(false);
+
+    React.useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    if (!mounted) {
+        return <div className="h-9 w-9 rounded-md bg-muted" />;
+    }
+
+    const isDark = theme === 'dark';
+
+    return (
+        <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+                'h-9 w-9 rounded-md transition-colors duration-200 ease-in-out',
+                'hover:bg-accent hover:text-accent-foreground',
+                'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+            )}
+            onClick={() => setTheme(isDark ? 'light' : 'dark')}
+            aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+        >
+            {isDark ? (
+                <Sun className="h-4 w-4 transition-transform duration-200 ease-in-out" />
+            ) : (
+                <Moon className="h-4 w-4 transition-transform duration-200 ease-in-out" />
+            )}
+            <span className="sr-only">Toggle theme</span>
+        </Button>
+    );
+}

--- a/src/components/shared/user-nav.tsx
+++ b/src/components/shared/user-nav.tsx
@@ -72,7 +72,6 @@ export function UserNav({ email, avatarUrl, displayName }: UserNavProps) {
                             <span>My Account</span>
                         </Link>
                     </DropdownMenuItem>
-                    {/* Theme toggle will be added here in the next milestone */}
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleSignOut} disabled={isPending}>


### PR DESCRIPTION
Implements the second milestone of Phase 5, introducing a full light and dark theme system using a simplified icon button.

- Adds and configures `next-themes` via a `ThemeProvider`.
- Creates a simple `ThemeToggleSwitch` button in the header.
- Updates `globals.css` with light/dark theme variables.
- Removes hard-coded 'dark' class from the root layout.