### PR TITLE
feat(navigation): implement contextual breadcrumbs and layouts

### DIFF
--- a/src/app/account/profile/page.tsx
+++ b/src/app/account/profile/page.tsx
@@ -3,8 +3,13 @@ import { redirect } from 'next/navigation';
 import { EditProfileForm } from '@/components/features/account/edit-profile-form';
 import { prisma } from '@/lib/db';
 import type { Profile } from '@prisma/client';
+import { PageHeader } from '@/components/shared/page-header';
 
-export default async function AccountProfilePage() {
+export default async function AccountProfilePage({
+    searchParams, // <--- ADD searchParams PROP
+}: {
+    searchParams: { from?: string };
+}) {
     const supabase = await createClient();
     const {
         data: { user },
@@ -15,21 +20,35 @@ export default async function AccountProfilePage() {
     }
 
     const profile: Profile | null = await prisma.profile.findUnique({
-        where: {
-            user_id: user.id,
-        },
+        where: { user_id: user.id },
     });
 
     if (!profile) {
         return <div>Error: Profile not found. Please contact support.</div>;
     }
 
+    const breadcrumbs = [];
+    if (searchParams.from) {
+        const spaceId = searchParams.from.split('/spaces/')[1];
+        if (spaceId) {
+            const fromSpace = await prisma.space.findUnique({
+                where: { id: spaceId },
+                select: { name: true },
+            });
+            if (fromSpace) {
+                breadcrumbs.push({ href: searchParams.from, label: fromSpace.name });
+            }
+        }
+    }
+    breadcrumbs.push({ href: '/account/profile', label: 'My Account' });
+
     return (
         <div className="container mx-auto max-w-2xl py-8">
-            <header className="mb-8">
-                <h1 className="text-3xl font-bold font-heading">Account Settings</h1>
-                <p className="text-muted-foreground">Manage your public profile details.</p>
-            </header>
+            <PageHeader
+                title="Account Settings"
+                description="Manage your public profile details."
+                breadcrumbs={breadcrumbs}
+            />
             <main>
                 <EditProfileForm profile={profile} />
             </main>

--- a/src/app/spaces/[spaceId]/layout.tsx
+++ b/src/app/spaces/[spaceId]/layout.tsx
@@ -89,6 +89,7 @@ export default async function SpaceLayout({
                             email={user.email}
                             avatarUrl={userProfile?.avatar_url}
                             displayName={userProfile?.display_name}
+                            currentSpaceId={space.id}
                         />
                     </div>
                 </div>

--- a/src/app/spaces/[spaceId]/log/new/page.tsx
+++ b/src/app/spaces/[spaceId]/log/new/page.tsx
@@ -1,4 +1,7 @@
 import { LogForm } from '@/components/features/log/LogForm';
+import { prisma } from '@/lib/db';
+import { notFound } from 'next/navigation';
+import { PageHeader } from '@/components/shared/page-header';
 
 export default async function NewLogInSpacePage({
     params,
@@ -7,14 +10,23 @@ export default async function NewLogInSpacePage({
 }) {
     const { spaceId } = await params;
 
+    const space = await prisma.space.findUnique({ where: { id: spaceId } });
+    if (!space) {
+        return notFound();
+    }
+
+    const breadcrumbs = [
+        { href: `/spaces/${space.id}`, label: space.name },
+        { href: `/spaces/${space.id}/log/new`, label: 'Log New Entry' },
+    ];
+
     return (
         <div className="container mx-auto max-w-2xl py-8">
-            <header className="mb-8">
-                <h1 className="text-3xl font-bold font-heading">Log a New Entry</h1>
-                <p className="text-muted-foreground">
-                    Find a movie or TV show and record your thoughts.
-                </p>
-            </header>
+            <PageHeader
+                title="Log a New Entry"
+                description="Find a movie or TV show and record your thoughts."
+                breadcrumbs={breadcrumbs}
+            />
             <LogForm spaceId={spaceId} />
         </div>
     );

--- a/src/app/spaces/[spaceId]/page.tsx
+++ b/src/app/spaces/[spaceId]/page.tsx
@@ -6,6 +6,7 @@ import { getFlicklogRewind } from '@/lib/data/stats-data';
 import { FlicklogRewind } from '@/components/features/dashboard/flicklog-rewind';
 import { LibraryGrid } from '@/components/features/dashboard/library-grid';
 import { LibraryGridSkeleton } from '@/components/features/dashboard/library-grid-skeleton';
+import { PageHeader } from '@/components/shared/page-header';
 
 
 export default async function SpacePage({
@@ -26,14 +27,20 @@ export default async function SpacePage({
         ? await getFlicklogRewind(user.id)
         : [];
 
+    const breadcrumbs = [
+        { href: `/spaces/${space.id}`, label: space.name },
+    ];
+
     return (
         <div>
-            <header className="mb-8">
-                <h1 className="font-heading text-4xl font-bold">{space.name}</h1>
-                <p className="text-lg text-muted-foreground">
-                    A shared library of your collective viewing experiences.
-                </p>
-            </header>
+            <PageHeader
+                title={space.name}
+                description={space.type === 'PERSONAL'
+                    ? 'Your personal viewing history.'
+                    : 'A shared library of your collective viewing experiences.'
+                }
+                breadcrumbs={breadcrumbs}
+            />
 
             <FlicklogRewind entries={rewindEntries} />
 

--- a/src/app/spaces/[spaceId]/settings/page.tsx
+++ b/src/app/spaces/[spaceId]/settings/page.tsx
@@ -15,6 +15,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { InviteMemberForm } from '@/components/features/space/invite-member-form';
 import { RemoveMemberButton } from '@/components/features/space/remove-member-button';
 import { DiscordWebhookForm } from '@/components/features/space/discord-webhook-form';
+import { PageHeader } from '@/components/shared/page-header';
 
 type SpaceWithMembersAndProfiles = Prisma.SpaceGetPayload<{
     include: {
@@ -74,7 +75,6 @@ export default async function SpaceSettingsPage({
     const { data: { user: currentUser } } = await supabase.auth.getUser();
 
     const { spaceId } = await params;
-
     const space = await getSpaceWithMembers(spaceId);
 
     if (!space || !currentUser) {
@@ -86,18 +86,18 @@ export default async function SpaceSettingsPage({
     );
     const isCurrentUserAdmin = currentUserMembership?.role === 'ADMIN';
 
-    return (
-        <div className="container py-8">
-            <div className="space-y-2">
-                <h1 className="font-heading text-3xl font-bold md:text-4xl">
-                    Space Settings
-                </h1>
-                <p className="text-muted-foreground text-lg">
-                    Manage your shared space &quot;{space.name}&quot;.
-                </p>
-            </div>
+    const breadcrumbs = [
+        { href: `/spaces/${space.id}`, label: space.name },
+        { href: `/spaces/${space.id}/settings`, label: 'Settings' },
+    ];
 
-            <Separator className="my-6" />
+    return (
+        <div className="space-y-6">
+            <PageHeader
+                title="Space Settings"
+                description={`Manage your shared space "${space.name}".`}
+                breadcrumbs={breadcrumbs}
+            />
 
             <div className="grid gap-8 md:grid-cols-3">
                 <div className="md:col-span-2">

--- a/src/app/spaces/[spaceId]/stats/page.tsx
+++ b/src/app/spaces/[spaceId]/stats/page.tsx
@@ -5,6 +5,9 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Star } from 'lucide-react';
 import Image from 'next/image';
 import { buildPosterUrl } from '@/lib/tmdb/tmdb-utils';
+import { PageHeader } from '@/components/shared/page-header';
+import { prisma } from '@/lib/db';
+import { notFound } from 'next/navigation';
 
 interface StatsPageProps {
     params: Promise<{
@@ -14,12 +17,23 @@ interface StatsPageProps {
 
 export default async function StatsPage({ params }: StatsPageProps) {
     const { spaceId } = await params;
+
+    const space = await prisma.space.findUnique({ where: { id: spaceId } });
+    if (!space) {
+        return notFound();
+    }
+
     const data = await getStatsDataForSpace(spaceId);
+
+    const breadcrumbs = [
+        { href: `/spaces/${space.id}`, label: space.name },
+        { href: `/spaces/${space.id}/stats`, label: 'Statistics' },
+    ];
 
     if (!data || data.length === 0) {
         return (
             <div>
-                <h1 className="text-3xl font-bold">Statistics</h1>
+                <PageHeader title="Statistics" breadcrumbs={breadcrumbs} />
                 <div className="mt-6 rounded-lg border bg-card p-8 text-center text-muted-foreground">
                     <p>Not enough data to generate stats yet.</p>
                     <p>Log some more entries to see your stats here!</p>
@@ -33,7 +47,7 @@ export default async function StatsPage({ params }: StatsPageProps) {
 
     return (
         <div className="space-y-8">
-            <h1 className="text-3xl font-bold">Statistics</h1>
+            <PageHeader title="Statistics" breadcrumbs={breadcrumbs} />
 
             {/* Critic's Corner Section */}
             <div>

--- a/src/app/spaces/new/page.tsx
+++ b/src/app/spaces/new/page.tsx
@@ -1,23 +1,41 @@
 import { CreateSpaceForm } from '@/components/features/space/create-space-form';
+import { prisma } from '@/lib/db';
+import { PageHeader } from '@/components/shared/page-header';
 
 /**
  * The page for creating a new Shared Space.
  * This is a server component that renders the CreateSpaceForm.
+ * It now includes a dynamic breadcrumb to return to the previous space.
  */
-export default function NewSpacePage() {
+export default async function NewSpacePage({
+    searchParams,
+}: {
+    searchParams: { from?: string };
+}) {
+    const breadcrumbs = [];
+    if (searchParams.from) {
+        const spaceId = searchParams.from.split('/spaces/')[1];
+        if (spaceId) {
+            const fromSpace = await prisma.space.findUnique({
+                where: { id: spaceId },
+                select: { name: true },
+            });
+            if (fromSpace) {
+                breadcrumbs.push({ href: searchParams.from, label: fromSpace.name });
+            }
+        }
+    }
+    breadcrumbs.push({ href: '/spaces/new', label: 'Create New Space' });
+
     return (
         <div className="container py-8">
-            <div className="space-y-2">
-                <h1 className="font-heading text-3xl font-bold md:text-4xl">
-                    Create a New Shared Space
-                </h1>
-                <p className="text-muted-foreground text-lg">
-                    A Shared Space is a collaborative library where you and your friends
-                    can log movies together. Give it a name to get started.
-                </p>
-            </div>
+            <PageHeader
+                title="Create a New Shared Space"
+                description="A Shared Space is a collaborative library where you and your friends can log movies together. Give it a name to get started."
+                breadcrumbs={breadcrumbs}
+            />
 
-            <div className="mt-8">
+            <div className="mt-8 max-w-md">
                 <CreateSpaceForm />
             </div>
         </div>

--- a/src/components/shared/page-header.tsx
+++ b/src/components/shared/page-header.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import * as React from 'react';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+
+interface BreadcrumbItem {
+    href: string;
+    label: string;
+}
+
+interface PageHeaderProps {
+    title: string;
+    description?: string;
+    breadcrumbs: BreadcrumbItem[];
+}
+
+export function PageHeader({ title, description, breadcrumbs }: PageHeaderProps) {
+    return (
+        <div className="mb-8">
+            <Breadcrumb className="mb-2">
+                <BreadcrumbList>
+                    {breadcrumbs.map((item, index) => (
+                        <React.Fragment key={item.href}>
+                            <BreadcrumbItem>
+                                {index === breadcrumbs.length - 1 ? (
+                                    <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                                ) : (
+                                    <BreadcrumbLink asChild>
+                                        <Link href={item.href}>{item.label}</Link>
+                                    </BreadcrumbLink>
+                                )}
+                            </BreadcrumbItem>
+                            {index < breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+                        </React.Fragment>
+                    ))}
+                </BreadcrumbList>
+            </Breadcrumb>
+            <h1 className="text-3xl font-bold font-heading">{title}</h1>
+            {description && (
+                <p className="mt-1 text-muted-foreground">{description}</p>
+            )}
+        </div>
+    );
+}

--- a/src/components/shared/space-switcher-client.tsx
+++ b/src/components/shared/space-switcher-client.tsx
@@ -1,7 +1,6 @@
 'use client';
-
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import { useState } from 'react';
 import type { Space } from '@prisma/client';
 import {
     Select,
@@ -11,42 +10,123 @@ import {
     SelectValue,
     SelectSeparator,
 } from '@/components/ui/select';
-import { PlusCircle } from 'lucide-react'; 
+import { PlusCircle, Users, Lock, Globe } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface SpaceSwitcherClientProps {
     currentSpace: Space;
     spaces: Space[];
+    isLoading?: boolean;
 }
+
+const getSpaceTypeIcon = (type: string) => {
+    switch (type.toLowerCase()) {
+        case 'personal':
+            return <Lock className="h-3.5 w-3.5 text-muted-foreground" />;
+        case 'shared':
+            return <Users className="h-3.5 w-3.5 text-muted-foreground" />;
+        case 'public':
+            return <Globe className="h-3.5 w-3.5 text-muted-foreground" />;
+        default:
+            return <Users className="h-3.5 w-3.5 text-muted-foreground" />;
+    }
+};
+
+
 
 export function SpaceSwitcherClient({
     currentSpace,
     spaces,
+    isLoading = false,
 }: SpaceSwitcherClientProps) {
     const router = useRouter();
+    const [isOpen, setIsOpen] = useState(false);
 
     const handleSwitch = (spaceId: string) => {
         if (spaceId === 'create-new') {
-            router.push('/spaces/new');
+            router.push(`/spaces/new?from=/spaces/${currentSpace.id}`);
             return;
         }
-        router.push(`/spaces/${spaceId}`);
+
+        const selectedSpace = spaces.find(space => space.id === spaceId);
+        if (selectedSpace && selectedSpace.id !== currentSpace.id) {
+            router.push(`/spaces/${spaceId}`);
+        }
+        setIsOpen(false);
     };
 
+    const sortedSpaces = [...spaces].sort((a, b) => {
+        if (a.id === currentSpace.id) return -1;
+        if (b.id === currentSpace.id) return 1;
+        return 0;
+    });
+
     return (
-        <Select onValueChange={handleSwitch} defaultValue={currentSpace.id}>
-            <SelectTrigger className="w-[200px] justify-start">
-                <div className="flex items-center gap-2">
-                    <span className="font-semibold truncate">{currentSpace.name}</span>
+        <Select
+            onValueChange={handleSwitch}
+            defaultValue={currentSpace.id}
+            open={isOpen}
+            onOpenChange={setIsOpen}
+            disabled={isLoading}
+        >
+            <SelectTrigger
+                className={cn(
+                    "w-[240px] justify-start font-medium transition-all duration-200",
+                    "hover:bg-accent/50 focus:ring-2 focus:ring-ring focus:ring-offset-2",
+                    "border-border/60 hover:border-border",
+                    isLoading && "opacity-50 cursor-not-allowed"
+                )}
+                aria-label={`Current space: ${currentSpace.name}. Click to switch spaces.`}
+            >
+                <div className="flex items-center gap-2 min-w-0">
+                    {getSpaceTypeIcon(currentSpace.type)}
+                    <SelectValue placeholder="Select a space">
+                        <span className="truncate">{currentSpace.name}</span>
+                    </SelectValue>
                 </div>
             </SelectTrigger>
-            <SelectContent>
-                {spaces.map((space) => (
-                    <SelectItem key={space.id} value={space.id}>
-                        {space.name}
-                    </SelectItem>
-                ))}
-                <SelectSeparator />
-                <SelectItem value="create-new" className="text-sm">
+            <SelectContent
+                className="w-[240px] p-1"
+                align="start"
+                sideOffset={4}
+            >
+                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    Your Spaces
+                </div>
+                {sortedSpaces.map((space) => {
+                    const isSelected = currentSpace.id === space.id;
+
+                    return (
+                        <SelectItem
+                            key={space.id}
+                            value={space.id}
+                            className={cn(
+                                "flex items-center gap-2 px-3 py-2.5 cursor-pointer",
+                                "hover:bg-accent/80 focus:bg-accent/80 transition-colors",
+                                "group relative min-h-[40px]",
+                                isSelected && "bg-accent/40 font-medium"
+                            )}
+                            aria-selected={isSelected}
+                        >
+                            <div className="flex items-center gap-2 min-w-0 flex-1">
+                                {getSpaceTypeIcon(space.type)}
+                                <span className="truncate text-sm">{space.name}</span>
+                            </div>
+                        </SelectItem>
+                    );
+                })}
+
+                <SelectSeparator className="my-2" />
+
+                <SelectItem
+                    value="create-new"
+                    className={cn(
+                        "flex items-center gap-2 px-3 py-2.5 cursor-pointer",
+                        "hover:bg-accent/80 focus:bg-accent/80 transition-colors",
+                        "text-sm font-medium text-primary hover:text-primary/90"
+                    )}
+                    aria-label="Create new space"
+                >
                     <div className="flex items-center gap-2">
                         <PlusCircle className="h-4 w-4" />
                         <span>Create New Space</span>

--- a/src/components/shared/user-nav.tsx
+++ b/src/components/shared/user-nav.tsx
@@ -22,9 +22,10 @@ interface UserNavProps {
     email?: string;
     avatarUrl?: string | null;
     displayName?: string | null;
+    currentSpaceId?: string;
 }
 
-export function UserNav({ email, avatarUrl, displayName }: UserNavProps) {
+export function UserNav({ email, avatarUrl, displayName,  currentSpaceId }: UserNavProps) {
     const [isPending, startTransition] = useTransition();
 
     const handleSignOut = () => {
@@ -42,6 +43,10 @@ export function UserNav({ email, avatarUrl, displayName }: UserNavProps) {
             .substring(0, 2)
             .toUpperCase()
         : email?.charAt(0).toUpperCase() || '?';
+
+    const accountHref = currentSpaceId
+        ? `/account/profile?from=/spaces/${currentSpaceId}`
+        : '/account/profile';
 
     return (
         <DropdownMenu>
@@ -67,7 +72,7 @@ export function UserNav({ email, avatarUrl, displayName }: UserNavProps) {
                 <DropdownMenuSeparator />
                 <DropdownMenuGroup>
                     <DropdownMenuItem asChild>
-                        <Link href="/account/profile">
+                        <Link href={accountHref}>
                             <User className="mr-2 h-4 w-4" />
                             <span>My Account</span>
                         </Link>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("hover:text-foreground transition-colors", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-foreground font-normal", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}


### PR DESCRIPTION
Completes Milestone 5.3, overhauling the application's navigation to resolve dead-ends and improve user orientation.

- Installs and configures the ShadCN Breadcrumb component.
- Introduces a reusable `PageHeader` component to standardize page titles and breadcrumb placement.
- Implements breadcrumb trails on all key nested pages (`/settings`, `/stats`, `/log/new`, `/account/profile`, `/spaces/new`), providing clear, clickable paths back up the hierarchy.
- Implements a dynamic 'return from' logic for the global 'My Account' and 'Create New Space' pages, using query parameters to create a seamless user flow.
- Refines the `SpaceSwitcher` component to visually highlight the active space in the dropdown list, improving clarity.