### PR TITLE
feat(ui): implement final polish and refinements

### DIFF
--- a/src/components/features/dashboard/library-grid.tsx
+++ b/src/components/features/dashboard/library-grid.tsx
@@ -6,6 +6,10 @@ import {
     type TmdbTvShowDetails,
 } from '@/lib/tmdb/tmdb-client';
 import { LogEntryCard } from '@/components/features/log/LogEntryCard';
+import { EmptyState } from '@/components/shared/empty-state';
+import { Film } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 type LogEntryWithDetails = Prisma.LogEntryGetPayload<{
     include: {
@@ -93,12 +97,15 @@ export async function LibraryGrid({ spaceId }: LibraryGridProps) {
 
     if (enrichedLogEntries.length === 0) {
         return (
-            <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted bg-muted/50 p-12 text-center">
-                <h3 className="text-xl font-semibold">Library is Empty</h3>
-                <p className="mt-2 text-sm text-muted-foreground">
-                    Log your first movie or TV show in this space to get started.
-                </p>
-            </div>
+            <EmptyState
+                icon={Film}
+                title="Library is Empty"
+                description="Log your first movie or TV show in this space to get started."
+            >
+                <Button asChild>
+                    <Link href={`/spaces/${spaceId}/log/new`}>+ Log New Entry</Link>
+                </Button>
+            </EmptyState>
         );
     }
 

--- a/src/components/features/space/discord-webhook-form.tsx
+++ b/src/components/features/space/discord-webhook-form.tsx
@@ -20,6 +20,17 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { saveDiscordWebhook } from '@/actions/space-actions';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 interface DiscordWebhookFormProps {
     spaceId: string;
@@ -83,9 +94,28 @@ export function DiscordWebhookForm({
                         </FormItem>
                     )}
                 />
-                <Button type="submit" disabled={isPending}>
-                    {isPending ? 'Saving...' : 'Save'}
-                </Button>
+                <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                        <Button type="button" disabled={isPending}>
+                            {isPending ? 'Saving...' : 'Save'}
+                        </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                                This will update the Discord webhook URL for this space.
+                                An incorrect URL will stop notifications from being sent.
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction onClick={form.handleSubmit(onSubmit)}>
+                                Continue
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
             </form>
         </Form>
     );

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { LucideIcon } from 'lucide-react';
+
+interface EmptyStateProps {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+    children?: React.ReactNode;
+    className?: string;
+}
+
+export function EmptyState({
+    icon: Icon,
+    title,
+    description,
+    children,
+    className,
+}: EmptyStateProps) {
+    return (
+        <div
+            className={cn(
+                'flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted bg-card/50 p-12 text-center',
+                className
+            )}
+        >
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+                <Icon className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <h2 className="mt-6 text-xl font-semibold font-heading">{title}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+            {children && <div className="mt-6">{children}</div>}
+        </div>
+    );
+}


### PR DESCRIPTION
Completes Milestone 5.4, adding a final layer of polish and robustness to the user experience.

- Introduces a reusable `EmptyState` component with an icon, title, description, and optional CTA.
- Refactors the `LibraryGrid` to use the new `EmptyState` component when a space has no logged entries.
- Adds a confirmation `AlertDialog` to the Discord Webhook form to prevent accidental changes.
- Verifies that all key forms throughout the application correctly implement pending/loading states on their submit buttons.